### PR TITLE
Prevent timing attacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "csv": "^1.1.0",
     "escape-regexp-component": "^1.0.2",
     "formidable": "^1.0.17",
-    "http-signature": "^0.11.0",
+    "http-signature": "^1.0.0",
     "lodash": "^4.17.4",
     "lru-cache": "^4.0.1",
     "mime": "^1.2.11",


### PR DESCRIPTION
fixes #1388

> Affected versions of the package are vulnerable to Timing Attacks due to time-variable comparison of signatures. A malicious user can guess a valid signature one char at a time by considering the time it takes a signature validation to fail.

https://snyk.io/vuln/npm:http-signature:20150122
